### PR TITLE
[ci skip] [skip ci] ***NO_CI*** Update maintainers, remove conda-forge/napari team

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,4 +120,4 @@ Feedstock Maintainers
 
 * [@adamltyson](https://github.com/adamltyson/)
 * [@goanpeca](https://github.com/goanpeca/)
-
+* [@jaimergp](https://github.com/jaimergp/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,3 +53,4 @@ extra:
   recipe-maintainers:
     - adamltyson
     - goanpeca
+    - jaimergp


### PR DESCRIPTION
The `conda-forge/napari` team was initially added as a way to support the migration to conda-forge.

The situation is now stable and we can prevent unwanted notifications by only leaving a subset of the team listed explicitly as maintainers.